### PR TITLE
RAM-Regler Konflikt behoben

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 
 name=MyFTBLauncher
 group=de.myftb
-version=0.9.2.2
+version=0.9.3
 description=MyFTB Minecraft Modpack Launcher
 
 organization=MyFTB

--- a/src/main/ui/src/components/Settings.react.js
+++ b/src/main/ui/src/components/Settings.react.js
@@ -78,7 +78,7 @@ export default class Settings extends React.Component {
         window.launcher.sendIpc('submit_settings', newSettings);
     }
 
-    onMinMemoryChange(){
+    onMinMemoryChange() {
         let min = this.minMemory.current;
         let max = this.maxMemory.current;
         if (min.getValue() > max.getValue()) {
@@ -86,7 +86,7 @@ export default class Settings extends React.Component {
         }
     }
 
-    onMaxMemoryChange(){
+    onMaxMemoryChange() {
         let min = this.minMemory.current;
         let max = this.maxMemory.current;
         if (max.getValue() < min.getValue()) {

--- a/src/main/ui/src/components/Settings.react.js
+++ b/src/main/ui/src/components/Settings.react.js
@@ -34,10 +34,6 @@ export default class Settings extends React.Component {
 
         this.onMinMemoryChange = this.onMinMemoryChange.bind(this);
         this.onMaxMemoryChange = this.onMaxMemoryChange.bind(this);
-
-        this.minMemory = React.createRef();
-        this.maxMemory = React.createRef();
-
     }
 
     componentDidMount() {
@@ -79,16 +75,16 @@ export default class Settings extends React.Component {
     }
 
     onMinMemoryChange() {
-        let min = this.minMemory.current;
-        let max = this.maxMemory.current;
+        let min = this.refs.minMemory;
+        let max = this.refs.maxMemory;
         if (min.getValue() > max.getValue()) {
             max.setValue(min.getValue());
         }
     }
 
     onMaxMemoryChange() {
-        let min = this.minMemory.current;
-        let max = this.maxMemory.current;
+        let min = this.refs.minMemory;
+        let max = this.refs.maxMemory;
         if (max.getValue() < min.getValue()) {
             min.setValue(max.getValue());
         }
@@ -114,11 +110,11 @@ export default class Settings extends React.Component {
             <div className="settings">
                 <div className="form-group">
                     <p>Minimaler RAM in MB</p>
-                    <RangeInput {...this.getOptionAttributes('minMemory')} min="1024" max="16384" ref={this.minMemory} onChange={this.onMinMemoryChange}></RangeInput>
+                    <RangeInput {...this.getOptionAttributes('minMemory')} min="1024" max="16384" ref="minMemory" onChange={this.onMinMemoryChange}></RangeInput>
                 </div>
                 <div className="form-group">
                     <p>Maximaler RAM in MB</p>
-                    <RangeInput {...this.getOptionAttributes('maxMemory')} min="1024" max="16384" ref={this.maxMemory} onChange={this.onMaxMemoryChange}></RangeInput>
+                    <RangeInput {...this.getOptionAttributes('maxMemory')} min="1024" max="16384" ref="maxMemory" onChange={this.onMaxMemoryChange}></RangeInput>
                 </div>
                 <div className="form-group">
                     <p>Java Argumente</p>

--- a/src/main/ui/src/components/Settings.react.js
+++ b/src/main/ui/src/components/Settings.react.js
@@ -81,7 +81,7 @@ export default class Settings extends React.Component {
     onMinMemoryChange(){
         let min = this.minMemory.current;
         let max = this.maxMemory.current;
-        if(min.getValue() > max.getValue()) {
+        if (min.getValue() > max.getValue()) {
             max.setValue(min.getValue());
         }
     }
@@ -89,7 +89,7 @@ export default class Settings extends React.Component {
     onMaxMemoryChange(){
         let min = this.minMemory.current;
         let max = this.maxMemory.current;
-        if(max.getValue() < min.getValue()) {
+        if (max.getValue() < min.getValue()) {
             min.setValue(max.getValue());
         }
     }

--- a/src/main/ui/src/components/Settings.react.js
+++ b/src/main/ui/src/components/Settings.react.js
@@ -31,6 +31,13 @@ export default class Settings extends React.Component {
             autoConfigOptions: {configs:[], types: [], constraints: []}
         };
         this.doInstallDirSelection = this.doInstallDirSelection.bind(this);
+
+        this.onMinMemoryChange = this.onMinMemoryChange.bind(this);
+        this.onMaxMemoryChange = this.onMaxMemoryChange.bind(this);
+
+        this.minMemory = React.createRef();
+        this.maxMemory = React.createRef();
+
     }
 
     componentDidMount() {
@@ -71,6 +78,22 @@ export default class Settings extends React.Component {
         window.launcher.sendIpc('submit_settings', newSettings);
     }
 
+    onMinMemoryChange(){
+        let min = this.minMemory.current;
+        let max = this.maxMemory.current;
+        if(min.getValue() > max.getValue()) {
+            max.setValue(min.getValue());
+        }
+    }
+
+    onMaxMemoryChange(){
+        let min = this.minMemory.current;
+        let max = this.maxMemory.current;
+        if(max.getValue() < min.getValue()) {
+            min.setValue(max.getValue());
+        }
+    }
+
     doInstallDirSelection() {
         window.launcher.sendIpc('open_directory_browser', false, (err, data) => {
             this.refs.installationDir.value = data.directory;
@@ -91,11 +114,11 @@ export default class Settings extends React.Component {
             <div className="settings">
                 <div className="form-group">
                     <p>Minimaler RAM in MB</p>
-                    <RangeInput {...this.getOptionAttributes('minMemory')} min="1024" max="16384"></RangeInput>
+                    <RangeInput {...this.getOptionAttributes('minMemory')} min="1024" max="16384" ref={this.minMemory} onChange={this.onMinMemoryChange}></RangeInput>
                 </div>
                 <div className="form-group">
                     <p>Maximaler RAM in MB</p>
-                    <RangeInput {...this.getOptionAttributes('maxMemory')} min="1024" max="16384"></RangeInput>
+                    <RangeInput {...this.getOptionAttributes('maxMemory')} min="1024" max="16384" ref={this.maxMemory} onChange={this.onMaxMemoryChange}></RangeInput>
                 </div>
                 <div className="form-group">
                     <p>Java Argumente</p>

--- a/src/main/ui/src/components/base/RangeInput.react.js
+++ b/src/main/ui/src/components/base/RangeInput.react.js
@@ -31,7 +31,23 @@ export default class RangeInput extends React.Component {
         this.updateBubble(true);
     }
 
+    callOnChange() {
+        if(this.props.onChange !== NaN) {
+            this.props.onChange()
+        }
+    }
+
     onValChanged() {
+        this.updateBubble(true);
+        this.callOnChange();
+    }
+
+    getValue() {
+        return parseInt(this.refs.slider.value);
+    }
+
+    setValue(value) {
+        this.refs.slider.value = value;
         this.updateBubble(true);
     }
 
@@ -40,6 +56,7 @@ export default class RangeInput extends React.Component {
         if (intVal !== NaN && this.refs.slider.value !== intVal && intVal >= this.refs.slider.min && intVal <= this.refs.slider.max) {
             this.refs.slider.value = intVal;
             this.updateBubble(false);
+            this.callOnChange();
         }
     }
 

--- a/src/main/ui/src/components/base/RangeInput.react.js
+++ b/src/main/ui/src/components/base/RangeInput.react.js
@@ -32,7 +32,7 @@ export default class RangeInput extends React.Component {
     }
 
     callOnChange() {
-        if(this.props.onChange !== NaN) {
+        if (this.props.onChange) {
             this.props.onChange()
         }
     }


### PR DESCRIPTION
Der Min-RAM-Regler kann nicht größer als der Max-RAM-Regler sein und umgekehrt.