### PR TITLE
Support für Modpack-spezifische Java Runtimes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 
 name=MyFTBLauncher
 group=de.myftb
-version=1.3.1
+version=1.3.2
 description=MyFTB Minecraft Modpack Launcher
 
 organization=MyFTB

--- a/src/main/java/de/myftb/launcher/Constants.java
+++ b/src/main/java/de/myftb/launcher/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
     public static final String launcherObjects = "http://packs.myftb.de/packs/objects/%s";
     public static final String packList = "http://packs.myftb.de/packs/packages.php?key=%s";
     public static final String packManifest = "http://packs.myftb.de/packs/%s";
+    public static final String runtimeIndex = "https://launcher.myftb.de/%s.json";
 
     public static final String versionManifestListUrl = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
     public static final String minecraftResources = "http://resources.download.minecraft.net/%s";

--- a/src/main/java/de/myftb/launcher/models/launcher/Index.java
+++ b/src/main/java/de/myftb/launcher/models/launcher/Index.java
@@ -15,28 +15,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package de.myftb.launcher.launch;
 
-import java.io.File;
-import java.nio.file.Files;
+package de.myftb.launcher.models.launcher;
 
-public class CopyDownloadCallable extends DownloadCallable {
-    private final File copy;
+import java.util.List;
 
-    public CopyDownloadCallable(Downloadable downloadable, File copy) {
-        super(downloadable);
-        this.copy = copy;
+public class Index {
+    private String name;
+    private List<IndexObject> objects;
+
+    public String getName() {
+        return this.name;
     }
 
-    @Override
-    public File call() throws Exception {
-        File targetFile = super.call();
+    public List<IndexObject> getObjects() {
+        return this.objects;
+    }
 
-        Files.copy(targetFile.toPath(), this.copy.toPath());
-        Files.write(new File(this.copy.getAbsolutePath() + ".sha1").toPath(),
-                this.downloadable.sha1.getBytes());
+    public static class IndexObject {
+        private String path;
+        private String hash;
+        private String url;
 
-        return targetFile;
+        public String getPath() {
+            return this.path;
+        }
+
+        public String getHash() {
+            return this.hash;
+        }
+
+        public String getUrl() {
+            return this.url;
+        }
+
     }
 
 }

--- a/src/main/java/de/myftb/launcher/models/modpacks/ModpackManifest.java
+++ b/src/main/java/de/myftb/launcher/models/modpacks/ModpackManifest.java
@@ -42,6 +42,7 @@ public class ModpackManifest {
     private String gameVersion;
     private MinecraftVersionManifest versionManifest; // TODO inheritsFrom korrekt beachten
     private Map<String, List<String>> launch;
+    private String runtime;
 
     private List<Feature> features;
     private List<FileTask> tasks;
@@ -68,6 +69,10 @@ public class ModpackManifest {
 
     public Map<String, List<String>> getLaunch() {
         return this.launch;
+    }
+
+    public String getRuntime() {
+        return this.runtime;
     }
 
     public List<Feature> getFeatures() {


### PR DESCRIPTION
Neuere Minecraft-Versionen benötigen mindestens Java 16. Damit wir auch ältere Modpacks noch supporten können, kann bei Modpacks nun individuell konfiguriert werden, welche Java Version genutzt werden soll.